### PR TITLE
Support Old Python, Add PW option, Print Unreachable Hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ Gather all the `/dev/disk/by-path` across all your hosts and generate a YAML rep
 
 [![GHA](https://github.com/sadsfae/ansible-dbp/actions/workflows/ansible-lint.yml/badge.svg)](https://github.com/sadsfae/ansible-dbp/actions)
 
+## Requirements
+* Python 2.7 or above on your remote hosts
+
 ## Usage
 
 * Add your hosts
@@ -12,6 +15,13 @@ vim hosts
 * Run it to generate `disk_paths_report.yml`
 ```bash
 ansible-playbook -i hosts disk_by_path.yml
+```
+>[!NOTE]
+> If you do not have [root ssh keys copied](https://github.com/sadsfae/ansible-sshkeys) you can pass root password via `-e`
+>
+
+```bash
+ansible-playbook -i hosts disk_report_playbook.yml -e "root_password=your_password"
 ```
 ## Example Report
 
@@ -27,4 +37,3 @@ e43-h13-000-r650.example.com:
     sdb: /dev/disk/by-path/pci-0000:67:00.0-scsi-0:2:2:0
     sdc: /dev/disk/by-path/pci-0000:67:00.0-scsi-0:2:1:0
 ```
-

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+remote_user = root

--- a/disk_by_path.yml
+++ b/disk_by_path.yml
@@ -4,6 +4,7 @@
   gather_facts: false
   become: true
   become_user: root
+  ignore_unreachable: true
 
   vars:
     ansible_become_pass: "{{ root_password | default(omit) }}"
@@ -28,6 +29,17 @@
   gather_facts: false
   become: false
 
+  vars:
+    unreachable_hosts: >-
+      {%- set unreachable = [] -%}
+      {%- for host in groups['all'] -%}
+      {%-   set task_result = hostvars[host].get('raw_disk_data', {}) -%}
+      {%-   if task_result.unreachable is defined and task_result.unreachable -%}
+      {%-     set _ = unreachable.append(host) -%}
+      {%-   endif -%}
+      {%- endfor -%}
+      {{ unreachable }}
+
   tasks:
     - name: 2. 📝 Aggregate data and write to YAML file
       ansible.builtin.copy:
@@ -36,22 +48,29 @@
           # Generated on: {{ lookup('pipe', 'date --iso-8601=seconds') }}
           {% set all_hosts_data = {} %}
           {% for host in groups['all'] %}
-          {%   set host_data = hostvars[host].raw_disk_data %}
-          {%   if host_data is defined and host_data.stdout %}
-          {%     set disk_paths = {} %}
-          {%     for line in host_data.stdout_lines %}
-          {%       set parts = line.split() %}
-          {%       if parts | length == 2 %}
-          {%         set device_name = parts[0] | basename %}
-          {%         set by_path_link = '/dev/disk/by-path/' + parts[1] %}
-          {%         set _ = disk_paths.update({device_name: by_path_link}) %}
+          {%   if host not in unreachable_hosts %}
+          {%     set host_data = hostvars[host].get('raw_disk_data', {}) %}
+          {%     if 'stdout' in host_data and host_data.stdout %}
+          {%       set disk_paths = {} %}
+          {%       for line in host_data.stdout_lines %}
+          {%         set parts = line.split() %}
+          {%         if parts | length == 2 %}
+          {%           set device_name = parts[0] | basename %}
+          {%           set by_path_link = '/dev/disk/by-path/' + parts[1] %}
+          {%           set _ = disk_paths.update({device_name: by_path_link}) %}
+          {%         endif %}
+          {%       endfor %}
+          {%       if disk_paths %}
+          {%         set _ = all_hosts_data.update({host: disk_paths}) %}
           {%       endif %}
-          {%     endfor %}
-          {%     if disk_paths %}
-          {%       set _ = all_hosts_data.update({host: disk_paths}) %}
           {%     endif %}
           {%   endif %}
           {% endfor %}
           {{ all_hosts_data | to_nice_yaml(indent=2) }}
         dest: "./disk_paths_report.yml"
         mode: '0644'
+
+    - name: 3. 📣 Report unreachable hosts
+      ansible.builtin.debug:
+        msg: "The following hosts were unreachable and were skipped: {{ unreachable_hosts }}"
+      when: unreachable_hosts | length > 0

--- a/disk_by_path.yml
+++ b/disk_by_path.yml
@@ -1,54 +1,57 @@
 ---
-- name: Gather and Report Physical Disk Paths
+- name: Gather Physical Disk Paths from all hosts
   hosts: all
-  gather_facts: true
+  gather_facts: false
   become: true
   become_user: root
 
-  tasks:
-    - name: 1. 🔍 Check if /dev/disk/by-path exists
-      ansible.builtin.stat:
-        path: /dev/disk/by-path
-      register: by_path_dir
+  vars:
+    ansible_become_pass: "{{ root_password | default(omit) }}"
 
-    - name: 2. 📋 Get by-path links for physical disks using a shell command
-      ansible.builtin.shell:
-        cmd: |
-          set -o pipefail
-          ls -l /dev/disk/by-path/ | awk 'NF>1 && $NF ~ /\.\.\/\.\.\/([svh]d[a-z]+|[xvd]d[a-z]+|nvme[0-9]+n[0-9]+)$/ {print $NF " " $9}'
-      register: disk_links
-      when: by_path_dir.stat.exists and by_path_dir.stat.isdir
+  tasks:
+    - name: 1. 📋 Get a single, canonical by-path link for each physical disk
+      ansible.builtin.raw: |
+        if [ -d /dev/disk/by-path ]; then
+          disk_re='\.\./\.\./([svh]d[a-z]+|[xvd]d[a-z]+|nvme[0-9]+n[0-9]+)$'
+          ls -l /dev/disk/by-path/ | \
+          awk -v disk_re="$disk_re" \
+            'NF>1 && $NF ~ disk_re && $9 !~ /-part[0-9]/ {print $NF " " $9}' | \
+          sort -k1,1 -u
+        fi
+      register: raw_disk_data
       changed_when: false
       failed_when: false
 
-    - name: 3. 🧠 Process command output into a fact
-      ansible.builtin.set_fact:
-        host_disk_paths: >
-          {%- set disk_paths = {} -%}
-          {%- for line in disk_links.stdout_lines | default([]) -%}
-            {%- set parts = line.split() -%}
-            {%- if parts | length == 2 -%}
-              {%- set device_name = parts[0] | basename -%}
-              {%- set by_path_link = parts[1] -%}
-              {%- set _ = disk_paths.update({device_name: '/dev/disk/by-path/' + by_path_link}) -%}
-            {%- endif -%}
-          {%- endfor -%}
-          {{ disk_paths }}
-      when: by_path_dir.stat.exists and by_path_dir.stat.isdir
+- name: Aggregate data and generate report
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
 
-    - name: 4. 📝 Aggregate data and write to YAML file
-      delegate_to: localhost
-      when: inventory_hostname == ansible_play_hosts_all[0]
+  tasks:
+    - name: 2. 📝 Aggregate data and write to YAML file
       ansible.builtin.copy:
         content: |
           # Physical Disk by-path report
-          # Generated on: {{ ansible_date_time.iso8601 }}
+          # Generated on: {{ lookup('pipe', 'date --iso-8601=seconds') }}
           {% set all_hosts_data = {} %}
-          {% for host in ansible_play_hosts_all %}
-            {% if hostvars[host].host_disk_paths is defined and hostvars[host].host_disk_paths %}
-              {% set _ = all_hosts_data.update({host: hostvars[host].host_disk_paths}) %}
-            {% endif %}
+          {% for host in groups['all'] %}
+          {%   set host_data = hostvars[host].raw_disk_data %}
+          {%   if host_data is defined and host_data.stdout %}
+          {%     set disk_paths = {} %}
+          {%     for line in host_data.stdout_lines %}
+          {%       set parts = line.split() %}
+          {%       if parts | length == 2 %}
+          {%         set device_name = parts[0] | basename %}
+          {%         set by_path_link = '/dev/disk/by-path/' + parts[1] %}
+          {%         set _ = disk_paths.update({device_name: by_path_link}) %}
+          {%       endif %}
+          {%     endfor %}
+          {%     if disk_paths %}
+          {%       set _ = all_hosts_data.update({host: disk_paths}) %}
+          {%     endif %}
+          {%   endif %}
           {% endfor %}
-          {{ all_hosts_data | to_nice_yaml }}
+          {{ all_hosts_data | to_nice_yaml(indent=2) }}
         dest: "./disk_paths_report.yml"
         mode: '0644'

--- a/hosts
+++ b/hosts
@@ -1,2 +1,5 @@
 # hosts here
+# assumes you have SSH keys on remote hosts
+# if not you can use:  https://github.com/sadsfae/ansible-sshkeys
+# otherwise use "-e "root_password=your_password"
 host01.example.com


### PR DESCRIPTION
Fixes: https://github.com/sadsfae/ansible-dbp/issues/5

* Support super old hosts (e.g. Python 2.7+)
* Also print hosts that were unreachable
* Add option to pass root password via `-e root_password=password"`